### PR TITLE
Gi valg om å inkludere reserverte transaksjoner

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -90,7 +90,43 @@ const Plus = ({ className }: IconProps) => (
   </svg>
 );
 
+const CreditCard = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={classNames('w-4 h-4', className)}
+  >
+    <path
+      d="M22 10H2M2 8.2L2 15.8C2 16.9201 2 17.4802 2.21799 17.908C2.40973 18.2843 2.71569 18.5903 3.09202 18.782C3.51984 19 4.07989 19 5.2 19L18.8 19C19.9201 19 20.4802 19 20.908 18.782C21.2843 18.5903 21.5903 18.2843 21.782 17.908C22 17.4802 22 16.9201 22 15.8V8.2C22 7.0799 22 6.51984 21.782 6.09202C21.5903 5.7157 21.2843 5.40974 20.908 5.21799C20.4802 5 19.9201 5 18.8 5L5.2 5C4.0799 5 3.51984 5 3.09202 5.21799C2.7157 5.40973 2.40973 5.71569 2.21799 6.09202C2 6.51984 2 7.07989 2 8.2Z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const CreditCardChecked = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={classNames('w-4 h-4', className)}
+  >
+    <path
+      d="M16 18L18 20L22 16M22 10H2M22 12V8.2C22 7.0799 22 6.51984 21.782 6.09202C21.5903 5.7157 21.2843 5.40974 20.908 5.21799C20.4802 5 19.9201 5 18.8 5H5.2C4.0799 5 3.51984 5 3.09202 5.21799C2.7157 5.40973 2.40973 5.71569 2.21799 6.09202C2 6.51984 2 7.0799 2 8.2V15.8C2 16.9201 2 17.4802 2.21799 17.908C2.40973 18.2843 2.71569 18.5903 3.09202 18.782C3.51984 19 4.0799 19 5.2 19H12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export default {
+  CreditCard,
+  CreditCardChecked,
   Delete,
   Edit,
   ExternalLink,

--- a/src/components/transactions.tsx
+++ b/src/components/transactions.tsx
@@ -2,7 +2,7 @@ import { h, Fragment } from 'preact';
 import { useMemo } from 'preact/hooks';
 import { useSelector } from 'react-redux';
 import Button from '../components/button';
-import { useAppSelector } from '../services';
+import { useAppDispatch, useAppSelector } from '../services';
 import type { EnrichedAccount } from '../services/accounts';
 import { getYnabKnowledgeByBudgetId } from '../services/ynab';
 import {
@@ -17,6 +17,9 @@ import type { SbankenGetTransactionsRequest } from '../services/sbanken.types';
 import { getAllSbankenTransactions } from '../services/sbanken.selectors';
 import { Spinner } from '../components/spinner';
 import { linkTransactions, TransactionSource } from '../services/transactions';
+import classNames from 'classnames';
+import Icons from '../components/icons';
+import { setShowReservedTransactions } from '../services/sbanken';
 
 interface TransactionsProps {
   account: EnrichedAccount;
@@ -24,6 +27,8 @@ interface TransactionsProps {
 }
 
 export const Transactions = ({ account, fromDate }: TransactionsProps) => {
+  const dispatch = useAppDispatch();
+
   const serverKnowledge = useAppSelector((state) =>
     getYnabKnowledgeByBudgetId(state, account.ynabBudgetId)
   );
@@ -37,7 +42,7 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
     [account.ynabBudgetId, fromDate, serverKnowledge]
   );
 
-  const { data: ynabTransactionsData, isLoading: ynabIsLoading } = useGetYnabTransactionsQuery(
+  const { data: ynabTransactionsData, isFetching: ynabIsLoading } = useGetYnabTransactionsQuery(
     ynabTransactionsRequest,
     {
       skip: !account.ynabLinkOk,
@@ -57,16 +62,39 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
     [account.sbankenAccountId, fromDate]
   );
 
-  const { data: sbankenTransactionsData, isLoading: sbankenIsLoading } =
+  const { data: sbankenTransactionsData, isFetching: sbankenIsLoading } =
     useGetSbankenTransactionsQuery(sbankenTransactionsRequest, { skip: !account.sbankenLinkOk });
+
+  const showReservedTransactions = useAppSelector(
+    (state) => state.sbanken.showReservedTransactions
+  );
 
   const transactionsForSbankenAccount = getAllSbankenTransactions(
     sbankenTransactionsData?.transactions
   );
 
+  const filteredTransactionsForSbankenAccount = useMemo(() => {
+    if (showReservedTransactions) {
+      return transactionsForSbankenAccount;
+    }
+
+    const filteredTransactions = transactionsForSbankenAccount.filter(
+      (transaction) => !transaction.isReserved
+    );
+    if (filteredTransactions.length === transactionsForSbankenAccount.length) {
+      return transactionsForSbankenAccount;
+    }
+
+    return filteredTransactions;
+  }, [showReservedTransactions, transactionsForSbankenAccount]);
+
   const transactions = useMemo(() => {
-    return linkTransactions(transactionsForSbankenAccount, transactionsForYnabAccount);
-  }, [transactionsForSbankenAccount, transactionsForYnabAccount]);
+    const linkedTransactions = linkTransactions(
+      filteredTransactionsForSbankenAccount,
+      transactionsForYnabAccount
+    );
+    return linkedTransactions;
+  }, [filteredTransactionsForSbankenAccount, transactionsForYnabAccount]);
 
   const [createTransaction, { isLoading: isCreatingTransaction }] = useCreateTransactionMutation();
 
@@ -81,7 +109,51 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
           </span>
         )}
       </h2>
-      <p className="mt-2 text-sm text-gray-500">Viser kun bokførte transaksjoner fra Sbanken.</p>
+      <div className="mt-2 flex items-center text-sm text-gray-500">
+        <div className="flex space-x-1 rounded-lg bg-gray-200 p-0.5">
+          <button
+            className={classNames('flex items-center rounded-md p-1.5 font-semibold lg:pr-3', {
+              'bg-white shadow': !showReservedTransactions,
+            })}
+            type="button"
+            onClick={() => dispatch(setShowReservedTransactions(false))}
+          >
+            <Icons.CreditCardChecked
+              className={classNames({
+                'text-pink-500': !showReservedTransactions,
+              })}
+            />
+            <span
+              className={classNames('sr-only lg:not-sr-only lg:ml-2', {
+                'text-gray-900': !showReservedTransactions,
+              })}
+            >
+              Kun bokførte
+            </span>
+          </button>
+          <button
+            className={classNames('flex items-center rounded-md p-1.5 font-semibold lg:pr-3', {
+              'bg-white shadow': showReservedTransactions,
+            })}
+            type="button"
+            onClick={() => dispatch(setShowReservedTransactions(true))}
+          >
+            <Icons.CreditCard
+              className={classNames({
+                'text-pink-500': showReservedTransactions,
+              })}
+            />
+            <span
+              className={classNames('sr-only lg:not-sr-only lg:ml-2', {
+                'text-gray-900': showReservedTransactions,
+              })}
+            >
+              Alle
+            </span>
+          </button>
+        </div>
+        <span className="ml-1">transaksjoner fra Sbanken vises.</span>
+      </div>
       <div className="overflow-hidden shadow mt-4 md:rounded-lg">
         <table className="min-w-full divide-y divide-gray-300">
           <thead className="bg-gray-50">
@@ -94,19 +166,19 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
               </th>
               <th
                 scope="col"
-                className="whitespace-nowrap px-2 py-3.5 text-left text-sm font-semibold text-gray-900"
+                className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
               >
                 Kilde
               </th>
               <th
                 scope="col"
-                className="whitespace-nowrap px-2 py-3.5 text-left text-sm font-semibold text-gray-900 w-full"
+                className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900 w-full"
               >
                 Beskrivelse
               </th>
               <th
                 scope="col"
-                className="whitespace-nowrap px-2 py-3.5 text-right text-sm font-semibold text-gray-900"
+                className="whitespace-nowrap py-3.5 pl-3 pr-4 sm:pr-6 text-right text-sm font-semibold text-gray-900"
               >
                 Beløp
               </th>
@@ -117,15 +189,19 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
               return (
                 <tr
                   key={`${transaction.sbankenTransactionId}:${transaction.ynabTranscationId}`}
-                  className="hover:bg-gray-50"
+                  className={classNames('hover:bg-gray-50', {
+                    'text-gray-900': !transaction.isReserved,
+                    'text-gray-500': transaction.isReserved,
+                  })}
                 >
-                  <td className="whitespace-nowrap py-2 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 font-numbers">
+                  <td className="whitespace-nowrap py-2 pl-4 pr-3 text-sm sm:pl-6 font-numbers">
                     {transaction.date.toISODate()}
                   </td>
-                  <td className="whitespace-nowrap px-2 py-2 text-sm font-medium text-gray-900">
+                  <td className="whitespace-nowrap px-3 py-2 text-sm font-medium">
                     {!!(transaction.source & TransactionSource.Sbanken) && 'Sbanken'}
                     {!!(transaction.source & TransactionSource.Sbanken) &&
-                      !(transaction.source & TransactionSource.Ynab) && (
+                      !(transaction.source & TransactionSource.Ynab) &&
+                      !transaction.isReserved && (
                         <Button
                           size="xs"
                           className="ml-1"
@@ -147,10 +223,11 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
                       )}
                     {!!(transaction.source & TransactionSource.Ynab) && 'YNAB'}
                   </td>
-                  <td className="whitespace-nowrap px-2 py-2 text-sm text-gray-900">
+                  <td className="whitespace-nowrap px-3 py-2 text-sm">
+                    {transaction.isReserved && '(Ikke bokført) '}
                     {transaction.description}
                   </td>
-                  <td className="whitespace-nowrap px-2 py-2 text-sm text-gray-500 text-right font-numbers">
+                  <td className="whitespace-nowrap py-2 pl-3 pr-4 sm:pr-6 text-sm text-right font-numbers">
                     {formatMoney(transaction.amount)}
                   </td>
                 </tr>

--- a/src/components/transactions.tsx
+++ b/src/components/transactions.tsx
@@ -152,7 +152,10 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
             </span>
           </button>
         </div>
-        <span className="ml-1">transaksjoner fra Sbanken vises.</span>
+        <span className="ml-2 lg:ml-1">
+          <span className="lg:sr-only">{showReservedTransactions ? 'Alle ' : 'Kun bokførte '}</span>
+          transaksjoner fra Sbanken vises.
+        </span>
       </div>
       <div className="overflow-hidden shadow mt-4 md:rounded-lg">
         <table className="min-w-full divide-y divide-gray-300">

--- a/src/components/transactions.tsx
+++ b/src/components/transactions.tsx
@@ -157,87 +157,91 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
           transaksjoner fra Sbanken vises.
         </span>
       </div>
-      <div className="overflow-hidden shadow mt-4 md:rounded-lg">
-        <table className="min-w-full divide-y divide-gray-300">
-          <thead className="bg-gray-50">
-            <tr>
-              <th
-                scope="col"
-                className="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
-              >
-                Dato
-              </th>
-              <th
-                scope="col"
-                className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-              >
-                Kilde
-              </th>
-              <th
-                scope="col"
-                className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900 w-full"
-              >
-                Beskrivelse
-              </th>
-              <th
-                scope="col"
-                className="whitespace-nowrap py-3.5 pl-3 pr-4 sm:pr-6 text-right text-sm font-semibold text-gray-900"
-              >
-                Beløp
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
-            {transactions.map((transaction) => {
-              return (
-                <tr
-                  key={`${transaction.sbankenTransactionId}:${transaction.ynabTranscationId}`}
-                  className={classNames('hover:bg-gray-50', {
-                    'text-gray-900': !transaction.isReserved,
-                    'text-gray-500': transaction.isReserved,
-                  })}
-                >
-                  <td className="whitespace-nowrap py-2 pl-4 pr-3 text-sm sm:pl-6 font-numbers">
-                    {transaction.date.toISODate()}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-sm font-medium">
-                    {!!(transaction.source & TransactionSource.Sbanken) && 'Sbanken'}
-                    {!!(transaction.source & TransactionSource.Sbanken) &&
-                      !(transaction.source & TransactionSource.Ynab) &&
-                      !transaction.isReserved && (
-                        <Button
-                          size="xs"
-                          className="ml-1"
-                          disabled={isCreatingTransaction}
-                          onClick={() => {
-                            void createTransaction({
-                              accountId: account.ynabAccountId,
-                              fromDate,
-                              transaction,
-                            });
-                          }}
-                        >
-                          ⚯
-                        </Button>
-                      )}
-                    {!!(transaction.source & TransactionSource.Sbanken) &&
-                      !!(transaction.source & TransactionSource.Ynab) && (
-                        <span className="text-gray-500"> ⚯ </span>
-                      )}
-                    {!!(transaction.source & TransactionSource.Ynab) && 'YNAB'}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-sm">
-                    {transaction.isReserved && '(Ikke bokført) '}
-                    {transaction.description}
-                  </td>
-                  <td className="whitespace-nowrap py-2 pl-3 pr-4 sm:pr-6 text-sm text-right font-numbers">
-                    {formatMoney(transaction.amount)}
-                  </td>
+      <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+          <div className="overflow-hidden shadow mt-4 md:rounded-lg">
+            <table className="min-w-full divide-y divide-gray-300">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                  >
+                    Dato
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                  >
+                    Kilde
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-3.5 text-left text-sm font-semibold text-gray-900 w-full"
+                  >
+                    Beskrivelse
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap py-3.5 pl-3 pr-4 sm:pr-6 text-right text-sm font-semibold text-gray-900"
+                  >
+                    Beløp
+                  </th>
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {transactions.map((transaction) => {
+                  return (
+                    <tr
+                      key={`${transaction.sbankenTransactionId}:${transaction.ynabTranscationId}`}
+                      className={classNames('hover:bg-gray-50', {
+                        'text-gray-900': !transaction.isReserved,
+                        'text-gray-500': transaction.isReserved,
+                      })}
+                    >
+                      <td className="whitespace-nowrap py-2 pl-4 pr-3 text-sm sm:pl-6 font-numbers">
+                        {transaction.date.toISODate()}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-sm font-medium">
+                        {!!(transaction.source & TransactionSource.Sbanken) && 'Sbanken'}
+                        {!!(transaction.source & TransactionSource.Sbanken) &&
+                          !(transaction.source & TransactionSource.Ynab) &&
+                          !transaction.isReserved && (
+                            <Button
+                              size="xs"
+                              className="ml-1"
+                              disabled={isCreatingTransaction}
+                              onClick={() => {
+                                void createTransaction({
+                                  accountId: account.ynabAccountId,
+                                  fromDate,
+                                  transaction,
+                                });
+                              }}
+                            >
+                              ⚯
+                            </Button>
+                          )}
+                        {!!(transaction.source & TransactionSource.Sbanken) &&
+                          !!(transaction.source & TransactionSource.Ynab) && (
+                            <span className="text-gray-500"> ⚯ </span>
+                          )}
+                        {!!(transaction.source & TransactionSource.Ynab) && 'YNAB'}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-sm">
+                        {transaction.isReserved && '(Ikke bokført) '}
+                        {transaction.description}
+                      </td>
+                      <td className="whitespace-nowrap py-2 pl-3 pr-4 sm:pr-6 text-sm text-right font-numbers">
+                        {formatMoney(transaction.amount)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </Fragment>
   );

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -177,7 +177,7 @@ export const Settings = () => {
                 </p>
                 <p>Ingenting blir slettet fra YNAB eller Sbanken.</p>
               </Dialog.Description>
-              <div className="mt-4 space-x-2">
+              <div className="mt-4 space-x-4">
                 <Button onClick={resetEverything}>Fjern</Button>
                 <Button onClick={() => setShowResetDialog(false)}>Avbryt</Button>
               </div>

--- a/src/service-worker/manager.tsx
+++ b/src/service-worker/manager.tsx
@@ -1,10 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { Dialog } from '@headlessui/react';
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
+import Button from '../components/button';
 import { CACHE_KEY_PREFIX, ServiceWorkerActionTypes } from './constants';
 
 export default function ServiceWorkerManager() {
   const [updatedWorker, setUpdatedWorker] = useState<ServiceWorker | undefined>();
+  const [showUpdatePrompt, setShowUpdatePrompt] = useState(false);
 
   useEffect(() => {
     const trackInstalling = (worker: ServiceWorker) => {
@@ -62,11 +64,38 @@ export default function ServiceWorkerManager() {
   useEffect(() => {
     if (!updatedWorker) return;
 
-    if (confirm('En ny versjon av Sbanken → YNAB er tilgjengelig. Vil du laste den inn nå?')) {
-      updatedWorker?.postMessage({ type: ServiceWorkerActionTypes.ApplyUpdate });
-      setUpdatedWorker(undefined);
-    }
+    setShowUpdatePrompt(true);
   }, [updatedWorker]);
 
-  return null;
+  const applyUpdate = () => {
+    updatedWorker?.postMessage({ type: ServiceWorkerActionTypes.ApplyUpdate });
+    setUpdatedWorker(undefined);
+  };
+
+  return (
+    <Dialog
+      open={showUpdatePrompt}
+      onClose={() => setShowUpdatePrompt(false)}
+      className="relative z-10"
+    >
+      <div className="fixed inset-0 bg-black bg-opacity-25" />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center">
+          <Dialog.Panel className="bg-white p-8 sm:rounded-lg shadow-2xl">
+            <Dialog.Title className="text-lg font-semibold">Ny versjon tilgjengelig</Dialog.Title>
+            <Dialog.Description className="mt-4">
+              <p>En ny versjon av Sbanken → YNAB er tilgjengelig. Vil du laste den inn nå?</p>
+              <p>Hvis ikke vil den lastes inn automatisk neste gang du bruker Sbanken → YNAB.</p>
+            </Dialog.Description>
+            <div className="mt-4 space-x-4">
+              <Button onClick={applyUpdate} importance="primary">
+                Ja
+              </Button>
+              <Button onClick={() => setShowUpdatePrompt(false)}>Nei</Button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </div>
+    </Dialog>
+  );
 }

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -58,7 +58,7 @@ export const getEnrichedAccounts = createSelector(
       const ynabAccount = ynabAccountsLookup[linkedAccount.ynabAccountId];
       const ynabBudget = ynabBudgetsLookup[linkedAccount.ynabBudgetId];
 
-      const sbankenUnclearedBalance = getSbankenUnclearedBalance(sbankenAccount);
+      const sbankenUnclearedBalance = +getSbankenUnclearedBalance(sbankenAccount).toFixed(2);
 
       const enrichedAccount: EnrichedAccount = {
         ...linkedAccount,

--- a/src/services/sbanken.api.ts
+++ b/src/services/sbanken.api.ts
@@ -10,14 +10,17 @@ import { DateTime } from 'luxon';
 import type { RootState } from '.';
 import { sbankenApiBaseUrl } from '../config';
 import { sbankenAccountsAdapter, sbankenCredentialsAdapter, validateSbankenToken } from './sbanken';
-import type {
+import {
   SbankenGetTransactionsEntities,
   SbankenGetTransactionsRequest,
+  SbankenGetTransactionsRequestMeta as SbankenGetTransactionsMeta,
+  SbankenReservedTransaction,
   SbankenSuccessResponse,
   SbankenTransaction,
+  SbankenTransactionSource,
   SbankenTransactionWithAccountId,
 } from './sbanken.types';
-import { inferDate } from './sbanken.utils';
+import { createSyntheticId, inferDate } from './sbanken.utils';
 
 export const sbankenTransactionsAdapter = createEntityAdapter<SbankenTransactionWithAccountId>({
   selectId: (transaction) => transaction.transactionId,
@@ -68,51 +71,96 @@ export const { useGetTransactionsQuery } = sbankenApi.injectEndpoints({
           throw new Error(`Invalid token for credential with ID ${credential.clientId}`);
         }
 
-        const url = `${sbankenApiBaseUrl}/Transactions/archive/${accountId}?startDate=${fromDate}`;
-        const headers = new Headers({
+        const headers: HeadersInit = {
           Authorization: `Bearer ${credential.token.value}`,
-        });
+        };
 
-        const result = (await baseQuery({
-          headers,
-          url,
+        const archiveUrl = `${sbankenApiBaseUrl}/Transactions/archive/${accountId}?startDate=${fromDate}`;
+        const archiveResult = (await baseQuery({
+          headers: new Headers(headers),
+          url: archiveUrl,
         })) as QueryReturnValue<
           SbankenSuccessResponse<SbankenTransaction>,
+          FetchBaseQueryError,
+          SbankenGetTransactionsMeta
+        >;
+
+        if (archiveResult.error) {
+          return archiveResult;
+        }
+
+        const { data, meta } = archiveResult;
+
+        let latestTransactionDate = DateTime.fromISO(fromDate);
+        const transformedTransactions = data.items.map<SbankenTransactionWithAccountId>(
+          (transaction) => {
+            const accountingDate = DateTime.fromISO(transaction.accountingDate);
+            if (accountingDate > latestTransactionDate) {
+              latestTransactionDate = accountingDate;
+            }
+            const transformedTransaction: SbankenTransactionWithAccountId = {
+              ...transaction,
+              accountingDate: accountingDate.toISODate(),
+              interestDate: DateTime.fromISO(transaction.interestDate).toISODate(),
+              accountId,
+            };
+
+            const inferredDate = inferDate(transformedTransaction);
+            if (inferredDate !== transformedTransaction.accountingDate) {
+              transformedTransaction.inferredDate = inferredDate;
+            }
+
+            return transformedTransaction;
+          }
+        );
+
+        const statementUrl = `${sbankenApiBaseUrl}/Transactions/${accountId}?startDate=${latestTransactionDate.toISODate()}`;
+        const statementResult = (await baseQuery({
+          headers: new Headers(headers),
+          url: statementUrl,
+        })) as QueryReturnValue<
+          SbankenSuccessResponse<SbankenReservedTransaction>,
           FetchBaseQueryError,
           FetchBaseQueryMeta
         >;
 
-        if (result.error) {
-          return result;
+        if (statementResult.error) {
+          if (meta) {
+            meta.partialError = statementResult.error;
+          }
+        } else {
+          for (const transaction of statementResult.data.items) {
+            // Archived transactions have already been fetched above
+            if (transaction.source === 'Archive') continue;
+
+            const transformedTransaction: SbankenTransactionWithAccountId = {
+              ...transaction,
+              accountingDate: DateTime.fromISO(transaction.accountingDate).toISODate(),
+              interestDate: DateTime.fromISO(transaction.interestDate).toISODate(),
+              accountId,
+              transactionId: createSyntheticId(transaction),
+              source: SbankenTransactionSource.AccountStatement,
+              isReserved: transaction.isReservation,
+            };
+
+            const inferredDate = inferDate(transformedTransaction);
+            if (inferredDate !== transformedTransaction.accountingDate) {
+              transformedTransaction.inferredDate = inferredDate;
+            }
+
+            transformedTransactions.push(transformedTransaction);
+          }
         }
 
-        const { data, meta } = result;
+        const transactionsState = sbankenTransactionsAdapter.setAll(
+          sbankenTransactionsAdapter.getInitialState(),
+          transformedTransactions
+        );
 
         return {
           meta,
           data: {
-            transactions: sbankenTransactionsAdapter.setAll(
-              sbankenTransactionsAdapter.getInitialState(),
-              data.items.map<SbankenTransactionWithAccountId>((transaction) => {
-                const transformedTransaction: SbankenTransactionWithAccountId = {
-                  ...transaction,
-                  accountingDate: transaction.accountingDate
-                    ? DateTime.fromISO(transaction.accountingDate).toISODate()
-                    : transaction.accountingDate,
-                  interestDate: transaction.interestDate
-                    ? DateTime.fromISO(transaction.interestDate).toISODate()
-                    : transaction.interestDate,
-                  accountId,
-                };
-
-                const inferredDate = inferDate(transformedTransaction);
-                if (inferredDate !== transformedTransaction.accountingDate) {
-                  transformedTransaction.inferredDate = inferredDate;
-                }
-
-                return transformedTransaction;
-              })
-            ),
+            transactions: transactionsState,
           },
         };
       },

--- a/src/services/sbanken.ts
+++ b/src/services/sbanken.ts
@@ -64,10 +64,7 @@ export function getSbankenUnclearedBalance(sbankenAccount?: SbankenAccount): num
   if (!sbankenAccount) return 0;
 
   if (sbankenAccount.accountType === 'Creditcard account') {
-    return +(
-      -sbankenAccount.balance -
-      (sbankenAccount.creditLimit - sbankenAccount.available)
-    ).toFixed(2);
+    return +(-sbankenAccount.balance - (sbankenAccount.creditLimit - sbankenAccount.available));
   }
 
   return sbankenAccount.available - sbankenAccount.balance;

--- a/src/services/sbanken.ts
+++ b/src/services/sbanken.ts
@@ -10,7 +10,7 @@ import {
 import memoize from 'lodash-es/memoize';
 import type { RootState } from '.';
 import { sbankenApiBaseUrl, sbankenIdentityServerUrl } from '../config';
-import { SBANKEN_CREDENTIALS_KEY } from './storage';
+import { SBANKEN_CREDENTIALS_KEY, SBANKEN_SHOW_RESERVED_KEY } from './storage';
 import { startAppListening } from './listener';
 import { fetchInitialData, RequestStatus, stripEmojis } from '../utils';
 import type {
@@ -44,6 +44,7 @@ export interface SbankenState {
   credentialIdByAccountId: Record<string, string>;
   credentials: EntityState<SbankenCredential>;
   requestStatusByCredentialId: Record<string, RequestStatus | undefined>;
+  showReservedTransactions: boolean;
 }
 
 export function validateSbankenToken(token?: SbankenToken): token is SbankenToken {
@@ -97,6 +98,16 @@ const initialCredentials = sbankenCredentialsAdapter.setAll(
   loadStoredCredentials()
 );
 
+function loadShowReservedTransactions() {
+  try {
+    return localStorage.getItem(SBANKEN_SHOW_RESERVED_KEY) === 'true';
+  } catch (e) {
+    console.debug(e);
+    localStorage.removeItem(SBANKEN_SHOW_RESERVED_KEY);
+    return false;
+  }
+}
+
 const initialState: SbankenState = {
   accounts: sbankenAccountsAdapter.getInitialState(),
   credentialIdByAccountId: {},
@@ -110,6 +121,7 @@ const initialState: SbankenState = {
       }
       return status;
     }, {}),
+  showReservedTransactions: loadShowReservedTransactions(),
 };
 
 export const getSbankenCredentials = sbankenCredentialsAdapter.getSelectors(
@@ -160,6 +172,9 @@ export const sbankenSlice = createSlice({
       sbankenCredentialsAdapter.removeOne(state.credentials, action.payload);
       delete state.requestStatusByCredentialId[action.payload];
     },
+    setShowReservedTransactions: (state, action: PayloadAction<boolean>) => {
+      state.showReservedTransactions = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addMatcher(
@@ -184,8 +199,12 @@ export const sbankenSlice = createSlice({
   },
 });
 
-export const { deleteCredential, putCredentialIdsByAccountIds, saveCredential } =
-  sbankenSlice.actions;
+export const {
+  deleteCredential,
+  putCredentialIdsByAccountIds,
+  saveCredential,
+  setShowReservedTransactions,
+} = sbankenSlice.actions;
 
 // FIXME: Remove imports
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -284,5 +303,14 @@ startAppListening({
     await Promise.allSettled(
       credentials.map((credential) => dispatch(fetchSbankenAccounts(credential)))
     );
+  },
+});
+
+/** Stores changes to "showReservedTransactions" in localStorage. */
+startAppListening({
+  actionCreator: setShowReservedTransactions,
+  effect: (_, { getState }) => {
+    const { showReservedTransactions } = getState().sbanken;
+    localStorage.setItem(SBANKEN_SHOW_RESERVED_KEY, JSON.stringify(showReservedTransactions));
   },
 });

--- a/src/services/sbanken.types.ts
+++ b/src/services/sbanken.types.ts
@@ -1,4 +1,5 @@
 import type { EntityState } from '@reduxjs/toolkit';
+import type { FetchBaseQueryError, FetchBaseQueryMeta } from '@reduxjs/toolkit/dist/query';
 
 export interface SbankenSuccessResponse<T> {
   availableItems: number;
@@ -20,13 +21,12 @@ export interface SbankenAccountWithClientId extends SbankenAccount {
   clientId: string;
 }
 
-enum SbankenTransactionSourceType {
+export enum SbankenTransactionSource {
   AccountStatement,
   Archive,
 }
 
-interface SbankenTransactionBase {
-  transactionId: string;
+export interface SbankenTransactionBase {
   accountingDate: string;
   interestDate: string;
   amount: number;
@@ -34,36 +34,24 @@ interface SbankenTransactionBase {
   transactionType: string;
   transactionTypeCode: number;
   transactionTypeText: string;
-  source: SbankenTransactionSourceType;
 }
 
-export type SbankenTransaction = SbankenTransactionBase &
-  (
-    | {
-        cardDetails: {
-          cardNumber: string;
-          currencyAmount: number;
-          currencyRate: number;
-          merchantCategoryCode: string;
-          merchantCategoryDescription: string;
-          merchantCity: string;
-          merchantName: string;
-          originalCurrencyCode: string;
-          purchaseDate: string;
-          transactionId: string;
-        };
-        cardDetailsSpecified: true;
-      }
-    | {
-        cardDetails: undefined;
-        cardDetailsSpecified: false;
-      }
-  );
+export interface SbankenTransaction extends SbankenTransactionBase {
+  transactionId: string;
+  source: SbankenTransactionSource;
+}
 
-export type SbankenTransactionWithAccountId = SbankenTransaction & {
-  accountId: string;
-  inferredDate?: string;
-};
+export interface SbankenReservedTransaction extends SbankenTransactionBase {
+  isReservation: boolean;
+  source: keyof typeof SbankenTransactionSource;
+}
+
+export type SbankenTransactionWithAccountId<T extends SbankenTransactionBase = SbankenTransaction> =
+  T & {
+    accountId: string;
+    inferredDate?: string;
+    isReserved?: boolean;
+  };
 
 export interface SbankenGetTransactionsRequest {
   accountId: string;
@@ -72,4 +60,8 @@ export interface SbankenGetTransactionsRequest {
 
 export interface SbankenGetTransactionsEntities {
   transactions: EntityState<SbankenTransactionWithAccountId>;
+}
+
+export interface SbankenGetTransactionsRequestMeta extends FetchBaseQueryMeta {
+  partialError?: FetchBaseQueryError;
 }

--- a/src/services/sbanken.utils.test.ts
+++ b/src/services/sbanken.utils.test.ts
@@ -1,4 +1,4 @@
-import type { SbankenTransaction } from './sbanken.types';
+import type { SbankenTransaction, SbankenTransactionBase } from './sbanken.types';
 import * as utils from './sbanken.utils';
 
 describe('inferDate', () => {
@@ -77,5 +77,80 @@ describe('inferDate', () => {
     const inferredDate = utils.inferDate(transaction);
 
     expect(inferredDate).toBe('2022-01-01');
+  });
+});
+
+describe('createSyntheticId', () => {
+  it('creates the same ID for the same transaction', () => {
+    const transaction: SbankenTransactionBase = {
+      accountingDate: '2023-01-17T00:00:00',
+      interestDate: '2023-01-17T00:00:00',
+      amount: -218.0,
+      text: '17.01 ABC DEF',
+      transactionType: 'NETTGIRO',
+      transactionTypeCode: 204,
+      transactionTypeText: 'NETTGIRO',
+    };
+
+    const id1 = utils.createSyntheticId(transaction);
+    const id2 = utils.createSyntheticId(transaction);
+
+    expect(id1).toEqual(id2);
+  });
+
+  it('creates the same ID for different transactions with the same base', () => {
+    const transaction1 = {
+      accountingDate: '2023-01-17T00:00:00',
+      interestDate: '2023-01-17T00:00:00',
+      amount: -218.0,
+      text: '17.01 ABC DEF',
+      transactionType: 'NETTGIRO',
+      transactionTypeCode: 204,
+      transactionTypeText: 'NETTGIRO',
+      isReservation: true,
+    } as SbankenTransactionBase;
+
+    const transaction2 = {
+      accountingDate: '2023-01-17T00:00:00',
+      interestDate: '2023-01-17T00:00:00',
+      amount: -218.0,
+      text: '17.01 ABC DEF',
+      transactionType: 'NETTGIRO',
+      transactionTypeCode: 204,
+      transactionTypeText: 'NETTGIRO',
+      isReservation: false,
+    } as SbankenTransactionBase;
+
+    const id1 = utils.createSyntheticId(transaction1);
+    const id2 = utils.createSyntheticId(transaction2);
+
+    expect(id1).toEqual(id2);
+  });
+
+  it('creates different IDs for different base transactions', () => {
+    const transaction1: SbankenTransactionBase = {
+      accountingDate: '2023-01-17T00:00:00',
+      interestDate: '2023-01-17T00:00:00',
+      amount: -218.0,
+      text: '17.01 ABC DEF',
+      transactionType: 'NETTGIRO',
+      transactionTypeCode: 204,
+      transactionTypeText: 'NETTGIRO',
+    };
+
+    const transaction2: SbankenTransactionBase = {
+      accountingDate: '2023-01-18T00:00:00',
+      interestDate: '2023-01-18T00:00:00',
+      amount: 500.0,
+      text: '18.01 ABC DEF',
+      transactionType: 'NETTGIRO',
+      transactionTypeCode: 204,
+      transactionTypeText: 'NETTGIRO',
+    };
+
+    const id1 = utils.createSyntheticId(transaction1);
+    const id2 = utils.createSyntheticId(transaction2);
+
+    expect(id1).not.toEqual(id2);
   });
 });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -2,8 +2,8 @@ import type { LinkedAccount } from './accounts';
 import type { SbankenCredential } from './sbanken';
 
 export const ACCOUNTS_STORAGE_KEY = 'accounts';
-export const RANGE_STORAGE_KEY = 'range';
 export const SBANKEN_CREDENTIALS_KEY = 'sbanken:credentials';
+export const SBANKEN_SHOW_RESERVED_KEY = 'sbanken:show_reserved';
 export const STORAGE_VERSION_KEY = 'version';
 export const YNAB_BUDGET_KEY = 'ynab:budget';
 export const YNAB_TOKENS_KEY = 'ynab:tokens';

--- a/src/services/ynab.api.ts
+++ b/src/services/ynab.api.ts
@@ -6,7 +6,8 @@ import {
   FetchBaseQueryMeta,
 } from '@reduxjs/toolkit/query/react';
 import { ynabApiBaseUrl } from '../config';
-import type {
+import {
+  YnabClearedState,
   YnabCreateTransactionRequest,
   YnabCreateTransactionResponse,
   YnabCreateTransactionsEntity,
@@ -47,7 +48,6 @@ export const ynabApi = createApi({
   endpoints: () => ({}),
 });
 
-// TODO: memoize
 const convertToYnabTransaction = (
   transaction: Transaction,
   accountId: string
@@ -57,7 +57,7 @@ const convertToYnabTransaction = (
   date: transaction.date.toISO(),
   import_id: transaction.sbankenTransactionId,
   memo: transaction.description,
-  cleared: 'cleared',
+  cleared: transaction.isReserved ? YnabClearedState.Uncleared : YnabClearedState.Cleared,
   approved: true,
 });
 

--- a/src/services/ynab.types.ts
+++ b/src/services/ynab.types.ts
@@ -140,3 +140,9 @@ export interface YnabCreateTransactionsEntity {
   transaction: YnabTransaction;
   serverKnowledge: number;
 }
+
+export enum YnabClearedState {
+  Uncleared = 'uncleared',
+  Cleared = 'cleared',
+  Reconciled = 'reconciled',
+}


### PR DESCRIPTION
En bedre løsning på https://github.com/Wedvich/sbanken-ynab/issues/71. I stedet for å aldri inkludere reserverte transaksjoner fra Sbanken, kan man nå velge om man vil inkludere dem eller ikke. Default er å ikke vise dem.