### PR TITLE
Inkluder payee når man oppretter transaksjoner

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/require-await': 'warn',
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/unbound-method': 'off',
     'arrow-parens': ['warn', 'always'],

--- a/src/components/transactions.tsx
+++ b/src/components/transactions.tsx
@@ -8,6 +8,7 @@ import { getYnabKnowledgeByBudgetId } from '../services/ynab';
 import {
   useGetTransactionsQuery as useGetYnabTransactionsQuery,
   useCreateTransactionMutation,
+  useGetPayeesQuery,
 } from '../services/ynab.api';
 import { useGetTransactionsQuery as useGetSbankenTransactionsQuery } from '../services/sbanken.api';
 import { getTransactionsGroupedByAccountId } from '../services/ynab.selectors';
@@ -100,6 +101,17 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
   }, [filteredTransactionsForSbankenAccount, transactionsForYnabAccount]);
 
   const [createTransaction, { isLoading: isCreatingTransaction }] = useCreateTransactionMutation();
+
+  const budgetIds = useAppSelector((state) => state.ynab.includedBudgets);
+
+  // TODO: Use in creation
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const ynabPayees = useGetPayeesQuery(
+    { budgetIds },
+    {
+      skip: !account.ynabLinkOk,
+    }
+  );
 
   return (
     <Fragment>

--- a/src/components/transactions.tsx
+++ b/src/components/transactions.tsx
@@ -102,16 +102,14 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
 
   const [createTransaction, { isLoading: isCreatingTransaction }] = useCreateTransactionMutation();
 
-  const budgetIds = useAppSelector((state) => state.ynab.includedBudgets);
-
-  // TODO: Use in creation
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const ynabPayees = useGetPayeesQuery(
-    { budgetIds },
+  const { data } = useGetPayeesQuery(
+    { budgetId: account.ynabBudgetId },
     {
       skip: !account.ynabLinkOk,
     }
   );
+
+  const payees = data?.payees ?? [];
 
   return (
     <Fragment>
@@ -240,6 +238,7 @@ export const Transactions = ({ account, fromDate }: TransactionsProps) => {
                                   accountId: account.ynabAccountId,
                                   fromDate,
                                   transaction,
+                                  payees,
                                 });
                               }}
                             >

--- a/src/services/ynab.api.ts
+++ b/src/services/ynab.api.ts
@@ -16,6 +16,7 @@ import {
   YnabCreateTransactionResponse,
   YnabCreateTransactionsEntity,
   YnabErrorResponse,
+  YnabGetPayeesEntities,
   YnabGetTransactionsEntities,
   YnabGetTransactionsRequest,
   YnabGetTransactionsResponse,
@@ -424,3 +425,35 @@ export const ynabClearTransactionsApi = ynabApi.injectEndpoints({
 });
 
 export const { useClearTransactionsMutation } = ynabClearTransactionsApi;
+
+export const getPayeesApi = ynabApi.injectEndpoints({
+  endpoints: (build) => ({
+    getPayees: build.query<YnabGetPayeesEntities, void>({
+      queryFn: async (_, { endpoint, getState }, extraOptions, baseQuery) => {
+        const state = getState() as RootState;
+
+        const budgetIds = state.ynab.includedBudgets;
+        if (!budgetIds.length) {
+          return {
+            data: {
+              payees: [],
+              serverKnowledgeByBudgetId: {},
+            },
+          };
+        }
+
+        // const lastEndpointKnowledge =
+        //   state.ynab.serverKnowledgeByBudgetId[budgetId]?.byEndpoint[endpoint] ?? 0;
+
+        return {
+          data: {
+            payees: [],
+            serverKnowledgeByBudgetId: {},
+          },
+        };
+      },
+    }),
+  }),
+});
+
+export const { useGetPayeesQuery } = getPayeesApi;

--- a/src/services/ynab.types.ts
+++ b/src/services/ynab.types.ts
@@ -175,8 +175,12 @@ export interface YnabClearTransactionsResponse {
   server_knowledge: number;
 }
 
-export interface YnabClearTransactionsMeta {
+export interface YnabRequestMeta {
   partialErrors?: Array<string>;
+}
+
+export interface YnabGetPayeesRequest {
+  budgetIds: Array<string>;
 }
 
 export interface YnabGetPayeesResponse {

--- a/src/services/ynab.types.ts
+++ b/src/services/ynab.types.ts
@@ -87,10 +87,6 @@ export interface YnabPayee {
   deleted: boolean;
 }
 
-export interface YnabPayeeWithBudgetId extends YnabPayee {
-  budget_id: string;
-}
-
 export interface YnabGetBudgetsResponse {
   budgets: Array<YnabBudgetWithAccounts>;
   default_budget: string | null;
@@ -138,6 +134,7 @@ export interface YnabCreateTransactionRequest {
   accountId: string;
   fromDate: string;
   transaction: Transaction;
+  payees: Array<YnabPayee>;
 }
 
 export interface YnabCreateTransactionResponse {
@@ -180,7 +177,7 @@ export interface YnabRequestMeta {
 }
 
 export interface YnabGetPayeesRequest {
-  budgetIds: Array<string>;
+  budgetId: string;
 }
 
 export interface YnabGetPayeesResponse {
@@ -189,6 +186,6 @@ export interface YnabGetPayeesResponse {
 }
 
 export interface YnabGetPayeesEntities {
-  payees: Array<YnabPayeeWithBudgetId>;
-  serverKnowledgeByBudgetId: Record<string, number>;
+  payees: Array<YnabPayee>;
+  serverKnowledge: number;
 }

--- a/src/services/ynab.types.ts
+++ b/src/services/ynab.types.ts
@@ -80,6 +80,17 @@ export interface YnabBudgetWithAccounts extends YnabBudget {
   accounts: Array<YnabAccount>;
 }
 
+export interface YnabPayee {
+  id: string;
+  name: string;
+  transfer_account_id: string;
+  deleted: boolean;
+}
+
+export interface YnabPayeeWithBudgetId extends YnabPayee {
+  budget_id: string;
+}
+
 export interface YnabGetBudgetsResponse {
   budgets: Array<YnabBudgetWithAccounts>;
   default_budget: string | null;
@@ -166,4 +177,14 @@ export interface YnabClearTransactionsResponse {
 
 export interface YnabClearTransactionsMeta {
   partialErrors?: Array<string>;
+}
+
+export interface YnabGetPayeesResponse {
+  payees: Array<YnabPayee>;
+  server_knowledge: number;
+}
+
+export interface YnabGetPayeesEntities {
+  payees: Array<YnabPayeeWithBudgetId>;
+  serverKnowledgeByBudgetId: Record<string, number>;
 }

--- a/src/services/ynab.utils.ts
+++ b/src/services/ynab.utils.ts
@@ -1,0 +1,16 @@
+import type { YnabPayee } from './ynab.types';
+
+export const inferPayeeIdFromDescription = (
+  payees: Array<YnabPayee>,
+  description?: string
+): string | undefined => {
+  if (!payees.length || !description?.length) return undefined;
+
+  const parts = description.toLowerCase().trim().split(' ');
+  const matches = payees.filter((payee) => {
+    const payeeName = payee.name.toLowerCase().trim().split(' ');
+    return payeeName.every((namePart) => parts.includes(namePart));
+  });
+
+  return matches.length === 1 ? matches[0].id : undefined;
+};


### PR DESCRIPTION
- Closes #69 

Når du oppretter en transaksjon fra Sbanken-Ynab i dag, blir ikke payee eller kategori tatt med, så du må uansett inn i YNAB for å sette dette manuelt. Med denne endringen vil appen forsøke å utlede payee fra teksten i Sbanken-transaksjonen.

Dette kan videreutvikles i fremtiden, men i første omgang blir det slik:

- Appen vil prøve å matche ord for ord i teksten mot payee-navn. Det behøver ikke være 100% treff, men det må være "nærme nok" (så dette vil nok også måtte justeres etter hvert).
- Kun eksisterende payees vil benyttes. Dersom appen ikke finner en treff, blir payee stående tom som før.
- Det er ingen konflikthåndtering, så hvis det er flere treff vil payee bli stående tom.

Siden vi bare bruker eksisterende payees, vil dette også automatisk sette kategori, på samme måte som YNAB i dag setter kategori basert på payee du velger.